### PR TITLE
Add task input/output annotations for Gradle 7 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ plugins {
     id 'groovy'
 
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.9.10'
+    id 'com.gradle.plugin-publish' version '0.15.0'
 
-    id 'net.minecrell.licenser' version '0.4.1'
+    id 'org.cadixdev.licenser' version '0.6.1'
 }
 
 sourceCompatibility = '1.8'
@@ -24,12 +24,13 @@ license {
     include '**/*.groovy'
 }
 
-task sourceJar(type: Jar) {
-    archiveClassifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
-task groovydocJar(type: Jar, dependsOn: groovydoc) {
+tasks.named('javadocJar', Jar).configure {
+    dependsOn 'groovydoc'
     archiveClassifier = 'groovydoc'
     from groovydoc.destinationDir
 }
@@ -41,6 +42,9 @@ gradlePlugin {
             implementationClass = 'org.cadixdev.gradle.gitpatcher.GitPatcher'
         }
     }
+}
+validatePlugins {
+    failOnWarning = false // abstract classes should be ok without annotations?
 }
 
 pluginBundle {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/Git.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/Git.groovy
@@ -22,6 +22,8 @@
 
 package org.cadixdev.gradle.gitpatcher
 
+import groovy.transform.CompileStatic
+
 class Git {
 
     File repo
@@ -52,6 +54,7 @@ class Git {
         return run(name, input)
     }
 
+    @CompileStatic
     static class Command {
 
         final Process process

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/GitPatcher.groovy
@@ -22,7 +22,7 @@
 
 package org.cadixdev.gradle.gitpatcher
 
-
+import groovy.transform.CompileStatic
 import org.cadixdev.gradle.gitpatcher.task.FindGitTask
 import org.cadixdev.gradle.gitpatcher.task.UpdateSubmodulesTask
 import org.cadixdev.gradle.gitpatcher.task.patch.ApplyPatchesTask
@@ -72,10 +72,12 @@ class GitPatcher implements Plugin<Project> {
         }
     }
 
+    @CompileStatic
     Project getProject() {
         return project
     }
 
+    @CompileStatic
     PatchExtension getExtension() {
         return extension
     }

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/PatchExtension.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/PatchExtension.groovy
@@ -22,6 +22,9 @@
 
 package org.cadixdev.gradle.gitpatcher
 
+import groovy.transform.CompileStatic
+
+@CompileStatic
 class PatchExtension {
 
     File root

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/FindGitTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/FindGitTask.groovy
@@ -24,10 +24,12 @@ package org.cadixdev.gradle.gitpatcher.task
 
 import org.cadixdev.gradle.gitpatcher.Git
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
-class FindGitTask extends DefaultTask {
+abstract class FindGitTask extends DefaultTask {
 
+    @Input
     String submodule
 
     @TaskAction

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/GitTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/GitTask.groovy
@@ -22,8 +22,10 @@
 
 package org.cadixdev.gradle.gitpatcher.task
 
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 
+@CompileStatic
 abstract class GitTask extends DefaultTask {
 
     File repo

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/SubmoduleTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/SubmoduleTask.groovy
@@ -22,12 +22,15 @@
 
 package org.cadixdev.gradle.gitpatcher.task
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+
 abstract class SubmoduleTask extends GitTask {
 
+    @Input
     String submodule
 
     {
         onlyIf { submodule != null }
     }
-
 }

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/SubmoduleTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/SubmoduleTask.groovy
@@ -22,9 +22,10 @@
 
 package org.cadixdev.gradle.gitpatcher.task
 
+import groovy.transform.CompileStatic
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 
+@CompileStatic
 abstract class SubmoduleTask extends GitTask {
 
     @Input

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/UpdateSubmodulesTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/UpdateSubmodulesTask.groovy
@@ -25,6 +25,8 @@ package org.cadixdev.gradle.gitpatcher.task
 import static java.lang.System.out
 
 import org.cadixdev.gradle.gitpatcher.Git
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 class UpdateSubmodulesTask extends SubmoduleTask {
@@ -46,8 +48,14 @@ class UpdateSubmodulesTask extends SubmoduleTask {
         git.submodule('update', '--init', '--recursive') >> out
     }
 
+    @Internal
     String getRef() {
         ref
+    }
+
+    @Override @InputDirectory
+    File getRepo() {
+        return super.getRepo()
     }
 
 }

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/UpdateSubmodulesTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/UpdateSubmodulesTask.groovy
@@ -24,6 +24,7 @@ package org.cadixdev.gradle.gitpatcher.task
 
 import static java.lang.System.out
 
+import groovy.transform.CompileStatic
 import org.cadixdev.gradle.gitpatcher.Git
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/ApplyPatchesTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/ApplyPatchesTask.groovy
@@ -27,13 +27,20 @@ import static java.lang.System.out
 import org.cadixdev.gradle.gitpatcher.Git
 import org.cadixdev.gradle.gitpatcher.task.UpdateSubmodulesTask
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class ApplyPatchesTask extends PatchTask {
 
+    @Internal
     UpdateSubmodulesTask updateTask
+
+    @Override @Internal
+    File getPatchDir() {
+        return super.getPatchDir();
+    }
 
     @Override @InputFiles
     File[] getPatches() {

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/MakePatchesTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/MakePatchesTask.groovy
@@ -27,7 +27,7 @@ import static java.lang.System.out
 import org.cadixdev.gradle.gitpatcher.Git
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -43,8 +43,8 @@ class MakePatchesTask extends PatchTask {
         return super.getRepo()
     }
 
-    @Override @InputFile
-    File getRefCache() {
+    @Override @Internal
+    File getRefCache() { // not used in this task
         return super.getRefCache()
     }
 
@@ -52,6 +52,12 @@ class MakePatchesTask extends PatchTask {
     File getPatchDir() {
         return super.getPatchDir()
     }
+
+    @Override @Internal
+    File[] getPatches() {
+        return super.getPatches()
+    }
+
 
     {
         outputs.upToDateWhen {

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/PatchTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/PatchTask.groovy
@@ -23,9 +23,11 @@
 package org.cadixdev.gradle.gitpatcher.task.patch
 
 import org.cadixdev.gradle.gitpatcher.task.SubmoduleTask
+import org.gradle.api.tasks.Internal
 
 abstract class PatchTask extends SubmoduleTask {
 
+    @Internal
     File root
 
     File patchDir
@@ -38,10 +40,12 @@ abstract class PatchTask extends SubmoduleTask {
         return patchDir.listFiles({ dir, name -> name.endsWith('.patch') } as FilenameFilter).sort()
     }
 
+    @Internal
     File getSubmoduleRoot() {
         return new File(root, submodule)
     }
 
+    @Internal
     File getGitDir() {
         return new File(repo, '.git')
     }
@@ -66,11 +70,13 @@ abstract class PatchTask extends SubmoduleTask {
         }
     }
 
+    @Internal
     String getCachedRef() {
         readCache()
         return cachedRefs[0]
     }
 
+    @Internal
     String getCachedSubmoduleRef() {
         readCache()
         return cachedRefs[1]

--- a/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/PatchTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/gitpatcher/task/patch/PatchTask.groovy
@@ -22,6 +22,7 @@
 
 package org.cadixdev.gradle.gitpatcher.task.patch
 
+import groovy.transform.CompileStatic
 import org.cadixdev.gradle.gitpatcher.task.SubmoduleTask
 import org.gradle.api.tasks.Internal
 
@@ -34,7 +35,7 @@ abstract class PatchTask extends SubmoduleTask {
 
     protected File[] getPatches() {
         if (!patchDir.directory) {
-            return []
+            return new File[0]
         }
 
         return patchDir.listFiles({ dir, name -> name.endsWith('.patch') } as FilenameFilter).sort()
@@ -56,6 +57,7 @@ abstract class PatchTask extends SubmoduleTask {
 
     private List<String> cachedRefs
 
+    @CompileStatic
     private void readCache() {
         if (cachedRefs == null) {
             File refCache = this.refCache
@@ -65,7 +67,7 @@ abstract class PatchTask extends SubmoduleTask {
                     !trimmed.empty && !trimmed.startsWith('#') ? trimmed : null
                 }.asList().asImmutable()
             } else {
-                this.cachedRefs = [].asImmutable()
+                this.cachedRefs = Collections.emptyList()
             }
         }
     }


### PR DESCRIPTION
Due to the complex system of overriding properties which are used in
different ways in different tasks, Gradle's compile-time flags several
false positives that Gradle accepts without error at runtime.

I've done some minor version bumps for other dependencies, and enabled the `@CompileStatic` annotation (based on the recent issue with `licenser`) and suggestions from the Gradle team -- though the core interaction with Gradle API is still unfotunately dynamic, since Groovy `Closure`s do not play well with `@CompileStatic`.

I've tested these changes in some of my Configurate work locally, and it appears to work fine.